### PR TITLE
Updating docker user configuration to support docker container actions in GitHub

### DIFF
--- a/0.X/Dockerfile
+++ b/0.X/Dockerfile
@@ -24,10 +24,6 @@ ENV HASHICORP_RELEASES=https://releases.hashicorp.com
 
 COPY ./docker-entrypoint.sh /bin
 
-# Create a non-root user to run the software.
-RUN addgroup ${NAME} && \
-    adduser -S -G ${NAME} ${NAME}
-
 # Set up certificates, base tools, and software.
 RUN set -eux && \
     apk add --no-cache ca-certificates curl gnupg libcap openssl jq iputils && \
@@ -63,5 +59,4 @@ RUN set -eux && \
     apk del gnupg openssl && \
     rm -rf /root/.gnupg
 
-USER ${NAME}
 ENTRYPOINT ["docker-entrypoint.sh"]


### PR DESCRIPTION
This PR contains a change to the dockerfile configuration that allow the Sentinel docker image to support GitHub container actions. 

The original config specified a USER key. This configuration is not supported, as documented in the [user](https://docs.github.com/en/free-pro-team@latest/actions/creating-actions/dockerfile-support-for-github-actions#user) section of the GitHub Actions documentation. 